### PR TITLE
Reimplementing SSL

### DIFF
--- a/SlopCrew.Server/ConnectionState.cs
+++ b/SlopCrew.Server/ConnectionState.cs
@@ -2,11 +2,8 @@ using SlopCrew.Common;
 using SlopCrew.Common.Network;
 using SlopCrew.Common.Network.Clientbound;
 using SlopCrew.Common.Network.Serverbound;
-using System.Numerics;
 using EmbedIO.WebSockets;
 using Serilog;
-using WebSocketSharp;
-using WebSocketSharp.Server;
 
 namespace SlopCrew.Server;
 
@@ -103,13 +100,6 @@ public class ConnectionState {
             Spraycan = visualUpdate.Spraycan
         };
     }
-
-    protected void OnClose(CloseEventArgs e) {
-        Log.Information("Connection closed from {Connection}: {Code} - {Reason}", this.DebugName(), e.Code,
-                        e.Reason);
-        Server.Instance.UntrackConnection(this);
-    }
-
 
     public string DebugName() {
         var endpoint = this.Context.RemoteEndPoint.ToString();

--- a/SlopCrew.Server/SlopCrew.Server.csproj
+++ b/SlopCrew.Server/SlopCrew.Server.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="EmbedIO" Version="3.5.2" />
         <PackageReference Include="Serilog" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Re-implemented SSL added in PR #5 which was removed during move to EmbedIO. Also removed server-side dependency on WebSocketSharp.

Certificate support is configurable via `SLOP_CERTIFICATE_PATH` and optionally `SLOP_CERTIFICATE_PASS` 

**This support is Windows only due to weird limitations of EmbedIO** (at least from our testing)