### PR TITLE
Optimized GetConnections(), GetNextID() and got rid of locks in SlopWebSocketModule

### DIFF
--- a/SlopCrew.Server/Server.cs
+++ b/SlopCrew.Server/Server.cs
@@ -3,7 +3,6 @@ using Serilog.Core;
 using SlopCrew.Common;
 using SlopCrew.Common.Network.Clientbound;
 using EmbedIO;
-using EmbedIO.WebSockets;
 using Graphite;
 using Constants = SlopCrew.Common.Constants;
 
@@ -178,12 +177,14 @@ public class Server {
     }
 
     public uint GetNextID() {
-        var ids = this.GetConnections().Select(x => x.Player?.ID).ToList();
-        var id = 0u;
-        while (ids.Contains(id)) id++;
+        var ids = new HashSet<uint>(this.GetConnections().Select(x => x.Player?.ID).Where(id => id.HasValue).Cast<uint>());
+        uint id = 0;
+        while (ids.Contains(id)) {
+            id++;
+        }
         return id;
     }
-
+    
     public List<ConnectionState> GetConnections() {
         return this.Module.Connections.Values.ToList();
     }

--- a/SlopCrew.Server/Server.cs
+++ b/SlopCrew.Server/Server.cs
@@ -185,7 +185,7 @@ public class Server {
         return id;
     }
     
-    public List<ConnectionState> GetConnections() {
-        return this.Module.Connections.Values.ToList();
+    public IEnumerable<ConnectionState> GetConnections() {
+        return this.Module.Connections.Values;
     }
 }


### PR DESCRIPTION
GetConnections() no longer makes a list everytime, so memory usage should be much lower
GetNextID() this is a minor change but still useful
I re-added ConcurrentDictionary for Connections in SlopWebSocketModule but there was a missing TryGetValue for OnMessageReceivedAsync before locks were brought in