### PR TITLE
Add more rich text tags that can be abused to regex

### DIFF
--- a/SlopCrew.Common/PlayerNameFilter.cs
+++ b/SlopCrew.Common/PlayerNameFilter.cs
@@ -18,9 +18,25 @@ public static class PlayerNameFilter {
         "[JKS] <color=lightblue>SpookPPL"
     };
     
-    // Regex out some tags
+    // Regex out rich tags that can be abused
     private static List<Regex> Regexes = new() {
-        new Regex("<size.*?>")
+        new Regex("<a href*?>"),
+        new Regex("<alpha*?>"),
+        new Regex("<br>"),
+        new Regex("<cspace.*?>"),
+        new Regex("<font .*?>"),
+        new Regex("<indent.*?>"),
+        new Regex("<line-.*?>"),
+        new Regex("<margin.*?>"),
+        new Regex("<mark.*?>"),
+        new Regex("<mspace.*?>"),
+        new Regex("<pos.*?>"),
+        new Regex("<rotate.*?>"),
+        new Regex("<size.*?>"),
+        new Regex("<space.*?>"),
+        new Regex("<style.*?>"),
+        new Regex("<voffset.*?>"),
+        new Regex("<width.*?>")
     };
 
     public static string DoFilter(string name) {


### PR DESCRIPTION
An addition to the work done towards #15, this PR adds more rich tags that can be abused to the regex list.

List of rich tags added to the list:
```
<a href>
<alpha>
<br>
<cspace>
<font>
<indent>
<line-height>
<line-indent>
<margin>
<mark>
<mspace>
<pos>
<rotate>
<space>
<style>
<voffset>
<width>
```
[(Descriptions of each on Unity's documentation page)](https://docs.unity3d.com/Manual/UIE-supported-tags.html)

Some of these might be harsh additions to the list, in which case they could be reconsidered.